### PR TITLE
Remaining() when past due returns negative value

### DIFF
--- a/TickTwo.cpp
+++ b/TickTwo.cpp
@@ -103,6 +103,7 @@ uint32_t TickTwo::elapsed() {
 	}
 
 uint32_t TickTwo::remaining() {
+	if (timer < elapsed()) return 0;
 	return timer - elapsed();
 	}
 

--- a/TickTwo.cpp
+++ b/TickTwo.cpp
@@ -102,8 +102,7 @@ uint32_t TickTwo::elapsed() {
 	else return micros() - lastTime;
 	}
 
-uint32_t TickTwo::remaining() {
-	if (timer < elapsed()) return 0;
+int32_t TickTwo::remaining() {
 	return timer - elapsed();
 	}
 

--- a/TickTwo.h
+++ b/TickTwo.h
@@ -126,10 +126,10 @@ public:
 
 	/** time remaining to the next tick
 	 *
-	 * @returns the remaining time to the next tick in ms or us depending from mode
+	 * @returns the remaining time to the next tick in ms or us depending from mode. If the execution is past due, it will return a negative value.
 	 *
 	 */
-	uint32_t remaining();
+	int32_t remaining();
 
 	/** get the state of the ticker
 	 *


### PR DESCRIPTION
In case of a long process without .update() calls, it happens that the execution is past due.
In such situation calling remains() would return something close to `0xffffffff`.