### PR TITLE
add method to set repeat after instantiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode
 *.DS_Store
 .DS_Store

--- a/TickTwo.cpp
+++ b/TickTwo.cpp
@@ -113,3 +113,8 @@ status_t TickTwo::state() {
 uint32_t TickTwo::counter() {
 	return counts;
 	}
+
+void TickTwo::repeats(uint32_t newrepeat) {
+	this->stop(); // stop running & paused timers
+	repeat = newrepeat;
+}

--- a/TickTwo.h
+++ b/TickTwo.h
@@ -149,7 +149,7 @@ public:
 	 * @param repeat number of repeats to execute
 	 * 
 	 */
-	void repeats(uint32_t repeat);
+	void repeats(uint32_t newrepeat);
 
 private:
 	bool tick();

--- a/TickTwo.h
+++ b/TickTwo.h
@@ -144,6 +144,13 @@ public:
 	 */
 	uint32_t counter();
 
+	/** set the number of repeats
+	 * 
+	 * @param repeat number of repeats to execute
+	 * 
+	 */
+	void repeats(uint32_t repeat);
+
 private:
 	bool tick();
 	bool enabled;

--- a/library.json
+++ b/library.json
@@ -5,10 +5,9 @@
   "repository":
   {
     "type": "git",
-    "url": "https://github.com/sstaub/TickTwo"
+    "url": "https://github.com/Sisyphos0/TickTwo.git"
   },
   "version": "4.4.0",
   "frameworks": "arduino",
   "platforms": "*"
 }
-

--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Stefan Staub <email@domain.com>
 sentence=A library for creating Tickers which can call repeating functions. Replaces delay() with non-blocking functions. Recommended for ESP and Arduino boards with mbed behind.
 paragraph=The Arduino Ticker Library allows you to create easily Ticker callbacks, which can call a function in a predetermined interval. You can change the number of repeats of the callbacks, if repeats is 0 the ticker runs in endless mode. Works like a "thread", where a secondary function will run when necessary. The library use no interupts of the hardware timers and works with the micros() / millis() function. You are not (really) limited in the number of Tickers.
 category=Timing
-url=https://github.com/sstaub/TickTwo
+url=https://github.com/Sisyphos0/TickTwo.git
 architectures=*


### PR DESCRIPTION
added the method _repeats()_ to set the number of repeats of a TickTwo instance.

If the timer is running or paused it will be stopped by the new method. So the calling function must issue a _start()_ call to restart the timer.  The count will restart at 0. 